### PR TITLE
Use gulp to create documentation and bundle.

### DIFF
--- a/dts.js
+++ b/dts.js
@@ -1,8 +1,0 @@
-var dts = require('dts-bundle');
-
-dts.bundle({
-    name: 'timezonecomplete',
-	baseDir: 'lib',
-	externals: false,
-    main: 'lib/index.d.ts'
-});

--- a/package.json
+++ b/package.json
@@ -52,9 +52,8 @@
     "gulp-filter": "^0.4.1",
     "gulp-rename": "^1.2.0",
     "gulp-tsc": "^0.9.1",
+    "gulp-typedoc": "^1.0.3",
     "gulp-wrap-umd": "^0.2.1",
-    "mocha": "^1.18.2",
-    "typedoc": "0.0.7",
-    "typescript": "1.0.1"
+    "mocha": "^1.18.2"
   }
 }

--- a/test/test-index.js
+++ b/test/test-index.js
@@ -1,4 +1,4 @@
-﻿/// <reference path="../typings/test.d.ts" />
+/// <reference path="../typings/test.d.ts" />
 var assert = require("assert");
 var chai = require("chai");
 var expect = chai.expect;


### PR DESCRIPTION
There is a bug in gulp-tsc which makes faulty references to .d.ts files, see https://github.com/kotas/gulp-tsc/issues/26

Therefore, the compile.bat file is still included.
